### PR TITLE
Improvements to Leptos example

### DIFF
--- a/tmpls/leptos/src/lib.rs
+++ b/tmpls/leptos/src/lib.rs
@@ -1,6 +1,7 @@
 use std::convert::Infallible;
 
 use leptos::prelude::*;
+use leptos::tachys::view::Position;
 use tmpls::{BigTable, Teams};
 
 #[derive(Debug, Default)]
@@ -28,7 +29,7 @@ impl tmpls::Benchmark for Benchmark {
                 }).collect::<Vec<_>>() }
             </table>
         };
-        *output = view.to_html();
+        view.to_html_with_buf(output, &mut Position::FirstChild, true, false, vec![]);
         Ok(())
     }
 
@@ -53,7 +54,7 @@ impl tmpls::Benchmark for Benchmark {
                 </body>
             </html>
         };
-        *output = view.to_html();
+        view.to_html_with_buf(output, &mut Position::FirstChild, true, false, vec![]);
         Ok(())
     }
 }

--- a/tmpls/leptos/src/lib.rs
+++ b/tmpls/leptos/src/lib.rs
@@ -16,48 +16,44 @@ impl tmpls::Benchmark for Benchmark {
         output: &mut Self::Output,
         input: &BigTable,
     ) -> Result<(), Self::Error> {
-        Owner::new().with(|| {
-            let BigTable { table } = input;
-            let view = view! {
-                <table>
-                    { table.iter().map(|row| view! {
-                        <tr>
-                            { row.iter().map(|col| view! {
-                                <td>{ *col }</td>
-                            }).collect::<Vec<_>>() }
-                        </tr>
-                    }).collect::<Vec<_>>() }
-                </table>
-            };
-            *output = view.to_html().replace("<!>", "");
-            Ok(())
-        })
+        let BigTable { table } = input;
+        let view = view! {
+            <table>
+                { table.iter().map(|row| view! {
+                    <tr>
+                        { row.iter().map(|col| view! {
+                            <td>{ *col }</td>
+                        }).collect::<Vec<_>>() }
+                    </tr>
+                }).collect::<Vec<_>>() }
+            </table>
+        };
+        *output = view.to_html().replace("<!>", "");
+        Ok(())
     }
 
     fn teams(&mut self, output: &mut Self::Output, input: &Teams) -> Result<(), Self::Error> {
-        Owner::new().with(|| {
-            let Teams { year, ref teams } = *input;
-            let view = view! {
-                <html>
-                    <head>
-                        <title>{ year }</title>
-                    </head>
-                    <body>
-                        <h1>"CSL "{ year }</h1>
-                        <ul>
-                            { teams.iter().enumerate().map(|(idx, team)| view! {
-                                <li class=(idx == 0).then_some("champion")>
-                                    <b>{ team.name.as_str() }</b>
-                                    ": "
-                                    { team.score }
-                                </li>
-                            }).collect::<Vec<_>>() }
-                        </ul>
-                    </body>
-                </html>
-            };
-            *output = view.to_html().replace("<!>", "");
-            Ok(())
-        })
+        let Teams { year, ref teams } = *input;
+        let view = view! {
+            <html>
+                <head>
+                    <title>{ year }</title>
+                </head>
+                <body>
+                    <h1>"CSL "{ year }</h1>
+                    <ul>
+                        { teams.iter().enumerate().map(|(idx, team)| view! {
+                            <li class=(idx == 0).then_some("champion")>
+                                <b>{ team.name.as_str() }</b>
+                                ": "
+                                { team.score }
+                            </li>
+                        }).collect::<Vec<_>>() }
+                    </ul>
+                </body>
+            </html>
+        };
+        *output = view.to_html().replace("<!>", "");
+        Ok(())
     }
 }

--- a/tmpls/leptos/src/lib.rs
+++ b/tmpls/leptos/src/lib.rs
@@ -28,7 +28,7 @@ impl tmpls::Benchmark for Benchmark {
                 }).collect::<Vec<_>>() }
             </table>
         };
-        *output = view.to_html().replace("<!>", "");
+        *output = view.to_html();
         Ok(())
     }
 
@@ -53,7 +53,7 @@ impl tmpls::Benchmark for Benchmark {
                 </body>
             </html>
         };
-        *output = view.to_html().replace("<!>", "");
+        *output = view.to_html();
         Ok(())
     }
 }


### PR DESCRIPTION
Nice benchmark! I saw this linked in another repo so took a look.

I saw a few changes that jumped out at me that would be useful to consider, so I left them here in separate commits. Feel free to pick and choose.

1. It's unnecessary to create an `Owner` per iteration, as these examples do not use any of the reactive features of the library so it's pure overhead
2. The `.replace("<!>", "")` entails not only string search but the allocation of a new `String` and a copy into it. I assume the goal is to remove any comments that we insert that are used as place markers for hydration, and possibly to guarantee identical HTML output for every template engine, but it slows things down considerably.
3. I set it up to render directly into the buffer given, as some of the other engines do, rather than into a new string -- just for the sake of parity.

Taken together I saw a pretty significant performance improvement running the benches locally.